### PR TITLE
add dired-single-up-directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,21 @@ it will prompt for a new directory to visit.
 Toggle between the 'magic' buffer name and the 'real' dired buffer
 name.  Will also seek to uniquify the 'real' buffer name.
 
+`M-x dired-single-up-directory`
+
+Like `dired-up-directory`, but reuses the buffer.  It handles the case
+where the dired buffer has multiple subdirs listed (with
+`dired-maybe-insert-subdir`), by just moving the point to the subdir
+without refreshing the buffer.
+
 ## Recommended Keybindings
 
 To use the single-buffer feature most effectively, I recommend adding the
 following code to your .emacs file.  Basically, it remaps the [Return] key
 to call the `dired-single-buffer` function instead of its normal
 function (`dired-advertised-find-file`).  Also, it maps the caret ("^")
-key to go up one directory, using the `dired-single-buffer` command
-instead of the normal one (`dired-up-directory`), which has the same effect
-as hitting [Return] on the parent directory line ("..")).  Finally, it maps
+key to go up one directory, using the `dired-single-up-directory` command
+instead of the normal one (`dired-up-directory`).  Finally, it maps
 a button-one click to the `dired-single-buffer-mouse` function, which
 does some mouse selection stuff, and then calls into the main
 `dired-single-buffer` function.
@@ -92,9 +98,7 @@ The following code will work whether or not dired has been loaded already.
   ;; <add other stuff here>
   (define-key dired-mode-map [return] 'dired-single-buffer)
   (define-key dired-mode-map [mouse-1] 'dired-single-buffer-mouse)
-  (define-key dired-mode-map "^"
-        (function
-         (lambda nil (interactive) (dired-single-buffer "..")))))
+  (define-key dired-mode-map "^" 'dired-single-up-directory)
 
 ;; if dired's already loaded, then the keymap will be bound
 (if (boundp 'dired-mode-map)

--- a/dired-single.el
+++ b/dired-single.el
@@ -32,6 +32,8 @@
   (set (make-local-variable 'byte-compile-dynamic) t))
 
 (eval-and-compile
+  (require 'cl-lib)
+  (require 'dired)
   (autoload 'dired-get-filename "dired"))
 
 ;;; **************************************************************************
@@ -213,6 +215,15 @@ Will also seek to uniquify the 'real' buffer name."
       (if existing-buffer
           (kill-buffer existing-buffer))
       (rename-buffer dired-single-magic-buffer-name))))
+
+;;;; ------------------------------------------------------------------------
+;;;###autoload
+(defun dired-single-up-directory (&optional other-window)
+  "Like `dired-up-directory' but with `dired-single-buffer'."
+  (interactive)
+  ;; replace dired with dired-single-buffer
+  (cl-letf (((symbol-function 'dired) (symbol-function 'dired-single-buffer)))
+    (dired-up-directory other-window)))
 
 ;;; **************************************************************************
 ;;; ***** we're done


### PR DESCRIPTION
This is better than `(dired-single-buffer "..")` because:
* it doesn't refresh the buffer when there are multiple subdirs (e.g. with `dired-maybe-insert-subdir`) and the parent dir is already listed in the buffer (it just moves the point in this case)
* it moves the point to the child dir after visiting the parent.  I.e. if you're in `/usr` and press `^`, the point will be on `usr` instead of `bin`.  

It's implemented by just replacing the function `dired` with `dired-single-buffer` and calling `dired-up-directory`.