### PR TITLE
Fix nil string error when looking at a header

### DIFF
--- a/dired-single.el
+++ b/dired-single.el
@@ -121,19 +121,23 @@ in another window."
   (let ((name (or default-dirname (dired-get-filename nil t))))
     ;; See if the selection is a directory or not.
     ;; assume directory if arg passed in
-    (if (or default-dirname
-            (and (dired-file-name-at-point)
-                 (file-directory-p (dired-file-name-at-point))))
-        ;; save current buffer's name
-        (let ((current-buffer-name (buffer-name)))
-          ;; go ahead and read in the directory
-          (find-alternate-file name)
-          ;; if the saved buffer's name was the magic name, rename this buffer
-          (if (and dired-single-use-magic-buffer
-                   (string= current-buffer-name dired-single-magic-buffer-name))
-              (rename-buffer dired-single-magic-buffer-name)))
-      ;; it's just a file
-      (find-file name))))
+    (cond ((or default-dirname
+               (and (dired-file-name-at-point)
+                    (file-directory-p (dired-file-name-at-point))))
+           ;; save current buffer's name
+           (let ((current-buffer-name (buffer-name)))
+             ;; go ahead and read in the directory
+             (find-alternate-file name)
+             ;; if the saved buffer's name was the magic name, rename this buffer
+             (if (and dired-single-use-magic-buffer
+                      (string= current-buffer-name dired-single-magic-buffer-name))
+                 (rename-buffer dired-single-magic-buffer-name))))
+          ;; Not looking at a header, it must be just a file
+          ((and name
+                (save-match-data
+                  (not (and (string-match "^  \\(.*\\):$" name)
+                            (file-name-absolute-p (match-string 1))))))
+           (find-file name)))))
 
 ;;;; ------------------------------------------------------------------------
 ;;;###autoload


### PR DESCRIPTION
The point in a dired buffer can be looking at a directory header. In which case any interactive functions in this package will result in a `wrong type argument: stringp, nil`. This PR fixes that issue.