### PR TITLE
Fix error when dired-get-filename is null

### DIFF
--- a/dired-single.el
+++ b/dired-single.el
@@ -13,6 +13,7 @@
 (eval-and-compile
   (require 'cl-lib)
   (require 'dired)
+  (require 'subr-x)
   (autoload 'dired-get-filename "dired"))
 
 ;;; **************************************************************************
@@ -97,7 +98,7 @@ a dired buffer).  If the current line represents a file, the file is visited
 in another window."
   (interactive)
   ;; use arg passed in or find name of current line
-  (let ((name (or default-dirname (dired-get-filename nil t))))
+  (when-let ((name (or default-dirname (dired-get-filename nil t))))
     (save-excursion
       (save-match-data
         ;; See if the selection is a directory or not.


### PR DESCRIPTION
When `dired-single-buffer` is called, point may be on a blank line at the bottom of the dired buffer, `dired-single-buffer` will throw an error from `find-find(nil)` in this case. This PR fixes this bug.