### PR TITLE
Make dired-single-up-directory function compatible with Emacs 28.1

### DIFF
--- a/dired-single.el
+++ b/dired-single.el
@@ -202,7 +202,9 @@ Will also seek to uniquify the 'real' buffer name."
   "Like `dired-up-directory' but with `dired-single-buffer'."
   (interactive)
   ;; replace dired with dired-single-buffer
-  (cl-letf (((symbol-function 'dired) (symbol-function 'dired-single-buffer)))
+  (cl-letf (((symbol-function 'dired) (symbol-function 'dired-single-buffer))
+            ;; Emacs 28 version of dired-up-directory implementation
+            ((symbol-function 'dired--find-possibly-alternative-file) (symbol-function 'dired-single-buffer)))
     (dired-up-directory other-window)))
 
 ;;; **************************************************************************


### PR DESCRIPTION
Emacs 28.1 version of `dired-up-directory` implementation calls `dired--find-possibly-alternative-file` function instead of `dired` function underneath. As a result, `dired-single-up-directory` function does exactly the same as `dired-up-directory` in Emacs 28.1.

It would be better to rewrite dired-single functions with respect to `dired-kill-when-opening-new-dired-buffer` user option (introduced in Emacs 28.1), but for now it should be enough to override both `dired` and `dired--find-possibly-alternative-file` functions.

This fix was tested only with Emacs 28.2. It should be backward compatible with earlier versions, but it's better to check.

The option `dired-kill-when-opening-new-dired-buffer` was introduced here:
https://git.savannah.gnu.org/cgit/emacs.git/commit/lisp/dired.el?id=5afe27624f7168713611dc9c24043091f8f820b6

Resolves: #3